### PR TITLE
Update author image when author email is not registered in Gravatar.

### DIFF
--- a/partials/author.hbs
+++ b/partials/author.hbs
@@ -11,7 +11,11 @@
         <i class="mdi mdi-google-plus"></i>
       </a>
     </nav>
-    <img class="image" src="{{image}}" />
+    {{#if image}}
+      <img class="image" src="{{image}}" />
+    {{else}}
+      <img class="image" src="{{@blog.url}}/shared/img/user-image.png" />
+    {{/if}}
   </div>
   <div class="author--info">
     <h5 class="name">{{name}}</h5>


### PR DESCRIPTION
Hi Nauzet, this is a small change to the author bio section, let me know if there may be any issues. In particular, I'm not very sure about whether {{@blog.url}} is the best way to reference Ghost's installation root.

Thanks,
Lin
