### PR TITLE
Fixed '[post.hbs] Missing helper: "image_url"' error

### DIFF
--- a/partials/author.hbs
+++ b/partials/author.hbs
@@ -12,7 +12,7 @@
       </a>
     </nav>
     {{#if profile_image}}
-      <img class="image" src="{{image_url profile_image}}" />
+      <img class="image" src="{{img_url profile_image}}" />
     {{else}}
       <img class="image" src="{{@blog.url}}/shared/img/user-image.png" />
     {{/if}}


### PR DESCRIPTION
With Ghost 1.8.4, `image_url` is deprecated, instead, use `img_url`  to output the URL for an image property.