### PR TITLE
Use Twitter URL from Ghost settings

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -44,11 +44,13 @@
         </div>
         <div class="half">
           <ul class="footer--suscriptions">
+            {{#if @blog.twitter}}
             <li>
-              <a href="#!">
+              <a href="{{twitter_url}}">
                 <i class="mdi mdi-twitter-box"></i>
               </a>
             </li>
+            {{/if}}
             <li>
               <a href="#!">
                 <i class="mdi mdi-google-plus-box"></i>


### PR DESCRIPTION
As per https://themes.ghost.org/docs/twitter_url

The helper `{{twitter_url}}` can be used (reading from Ghost settings), instead of a hard-coded URL.