### PR TITLE
Switching to a CDN that leverages browser caching

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -16,7 +16,7 @@
 
     {{! CDN resources }}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css" />
-    <link rel="stylesheet" href="//cdn.materialdesignicons.com/1.3.41/css/materialdesignicons.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/MaterialDesign-Webfont/1.3.41/css/materialdesignicons.min.css" />
 
     {{! Styles }}
     <link rel="stylesheet" href="{{asset "assets/css/screen.css"}}" />


### PR DESCRIPTION
Google PageSpeed Insights identified that the previous CDN didn't use `Cache-Control` headers in the HTTP response, so browser caching wasn't leveraged. This change allows for caching, and also # of reduces remote dependencies.